### PR TITLE
More robust JSON-LD processing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @RinkeHoekstra

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": {"name": "Rinke Hoekstra", "email": "r.hoekstra@elsevier.com"},
   "repository": "https://github.com/elsevierlabs-os/linked-data",
   "description": "This extension provides shortcuts for standard Linked Data operations, format conversions, validation, querying and a graph visualization.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "icon": "media/img/lde-icon.png",
   "engines": {
     "vscode": "^1.59.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -334,7 +334,7 @@ async function updateGraphView(document:vscode.TextDocument, extensionUri: vscod
 				<head>
 					<meta charset="UTF-8">
 					<meta name="viewport" content="width=device-width, initial-scale=1.0">
-					<title>JSON-LD Viewer</title>
+					<title>Graph Viewer</title>
 					<!--
 					Use a content security policy to only allow loading images from https or from our extension directory,
 					and only allow scripts that have a specific nonce.


### PR DESCRIPTION
The rdflib.js backend was causing issues (ignored triples) with some shapes of JSON-LD, in particular where multiple nested named graphs appeared in the JSON structure. This version circumvents this by first using the `toRDF` function from jsonld.js to produce NQuads, and then loading that into the rdflib.js backend.